### PR TITLE
Server component attributes

### DIFF
--- a/internal/dbtools/fixtures.go
+++ b/internal/dbtools/fixtures.go
@@ -1124,7 +1124,7 @@ func setupInstalledFirmwareFixtures(ctx context.Context, db *sqlx.DB) error {
 			ServerComponentID: FixtureNemoLeftFin.ID,
 		},
 		{
-			Version:           "1.0",
+			Version:           "2.0",
 			ServerComponentID: FixtureNemoRightFin.ID,
 		},
 	}

--- a/pkg/api/v1/component_status.go
+++ b/pkg/api/v1/component_status.go
@@ -17,7 +17,7 @@ import (
 
 type ComponentStatus struct {
 	ID                uuid.UUID `json:"id,omitempty"`
-	ServerComponentID uuid.UUID `json:"server_component_id,omitempty" binding:"required"`
+	ServerComponentID uuid.UUID `json:"server_component_id,omitempty"`
 	ComponentName     string    `json:"component_name,omitempty"`
 	Health            string    `json:"health" binding:"required"`
 	State             string    `json:"state" binding:"required"`

--- a/pkg/api/v1/server_component_get_params.go
+++ b/pkg/api/v1/server_component_get_params.go
@@ -5,10 +5,9 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/metal-automata/fleetdb/internal/models"
 	"github.com/volatiletech/sqlboiler/v4/queries/qm"
 	"go.uber.org/zap"
-
-	"github.com/metal-automata/fleetdb/internal/models"
 )
 
 const (
@@ -285,7 +284,7 @@ func (s *serverComponentQueryMods) capabilities() []qm.QueryMod {
 				"%s on %s = %s",
 				models.TableNames.ComponentCapabilities,
 				models.ServerComponentTableColumns.ID,
-				models.ComponentCapabilityColumns.ServerComponentID,
+				models.ComponentCapabilityTableColumns.ServerComponentID,
 			),
 		),
 		// Load relationship in db model struct field R

--- a/pkg/api/v1/server_get_params.go
+++ b/pkg/api/v1/server_get_params.go
@@ -41,34 +41,44 @@ func (p *ServerGetParams) encode() string {
 		return ""
 	}
 
-	values := url.Values{}
-	includes := []string{}
+	// server attribute include parameters
+	serverIncludes := []string{}
 
-	// Handle BMC include
+	// BMC information to be included
 	if p.IncludeBMC {
-		includes = append(includes, includeServerBMC)
+		serverIncludes = append(serverIncludes, includeServerBMC)
 	}
 
-	// Handle Status include
+	// Server status to be included
 	if p.IncludeStatus {
-		includes = append(includes, includeServerStatus)
+		serverIncludes = append(serverIncludes, includeServerStatus)
 	}
 
-	if p.IncludeComponents {
-		includes = append(includes, includeComponents)
+	// url values to be encoded as a query string
+	urlValues := url.Values{}
 
-		// Add component includes if they exist
+	// Component information to be included
+	if p.IncludeComponents {
+		serverIncludes = append(serverIncludes, includeComponents)
+
+		// Component attributes to be included
 		if p.ComponentParams != nil {
-			p.ComponentParams.encode()
+			p.ComponentParams.setQuery(urlValues)
 		}
 	}
 
-	// Set includes if we have any
-	if len(includes) > 0 {
-		values.Set("include", strings.Join(includes, ","))
+	if len(serverIncludes) > 0 {
+		// ComponentParams.setQuery may have set "include", prefix server includes for readability
+		includeVals, exists := urlValues["include"]
+		if exists {
+			finalVals := strings.Join(serverIncludes, ",") + "," + includeVals[0]
+			urlValues.Set("include", finalVals)
+		} else {
+			urlValues.Set("include", strings.Join(serverIncludes, ","))
+		}
 	}
 
-	return values.Encode()
+	return urlValues.Encode()
 }
 
 // Decode parses URL query parameters into ServerGetParams
@@ -126,12 +136,13 @@ func (p *ServerGetParams) setQuery(q url.Values) {
 		return
 	}
 
-	if p.encode() == "" {
+	encoded := p.encode()
+	if encoded == "" {
 		return
 	}
 
 	// Parse the encoded string into values
-	values, err := url.ParseQuery(p.encode())
+	values, err := url.ParseQuery(encoded)
 	if err != nil {
 		return
 	}

--- a/pkg/api/v1/server_get_params.go
+++ b/pkg/api/v1/server_get_params.go
@@ -183,6 +183,13 @@ func (p *ServerGetParams) queryMods(serverID string) []qm.QueryMod {
 		qm.Load(models.ServerRels.Model),
 	}
 
+	// Add server components if required
+	//
+	// Note: for server component attributes to be included, use r.componentsByServer()
+	if p.IncludeComponents {
+		mods = append(mods, qm.Load(models.ServerRels.ServerComponents))
+	}
+
 	// Add server status query mods if requested
 	if p.IncludeStatus {
 		mods = append(mods,
@@ -234,29 +241,7 @@ func (p *ServerGetParams) queryMods(serverID string) []qm.QueryMod {
 				),
 			),
 			qm.Where(fmt.Sprintf("t.%s=?", models.ServerCredentialTypeColumns.Slug), "bmc"),
-			// Load relationship in db model struct field R
-			// qm.Load(models.ServerCredentialRels.ServerCredentialType),
 		)
-	}
-
-	if p.IncludeComponents {
-		mods = append(mods,
-			// left join component data
-			qm.LeftOuterJoin(
-				fmt.Sprintf(
-					"%s on %s = %s",
-					models.TableNames.ServerComponents,
-					models.ServerTableColumns.ID,
-					models.ServerComponentTableColumns.ServerID,
-				),
-			),
-			qm.Load(models.ServerRels.ServerComponents),
-		)
-
-		// Add component query mods if component params are present
-		if p.ComponentParams != nil {
-			mods = append(mods, p.ComponentParams.queryMods(false)...)
-		}
 	}
 
 	return mods

--- a/pkg/api/v1/server_get_params_test.go
+++ b/pkg/api/v1/server_get_params_test.go
@@ -46,12 +46,25 @@ func TestServerGetParamsEncode(t *testing.T) {
 			expected: "include=s.components",
 		},
 		{
+			name: "components with attributes",
+			params: &ServerGetParams{
+				IncludeComponents: true,
+				ComponentParams: &ServerComponentGetParams{
+					InstalledFirmware: true,
+					Capabilities:      true,
+					Status:            true,
+				},
+			},
+			expected: "include=s.components,c.capabilities,c.installed_firmware,c.status",
+		},
+
+		{
 			name: "bmc and status",
 			params: &ServerGetParams{
 				IncludeBMC:    true,
 				IncludeStatus: true,
 			},
-			expected: "include=s.bmc%2Cs.status",
+			expected: "include=s.bmc,s.status",
 		},
 		{
 			name: "empty component params",
@@ -66,7 +79,9 @@ func TestServerGetParamsEncode(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := tt.params.encode()
-			assert.Equal(t, tt.expected, result)
+			got, err := url.QueryUnescape(result)
+			assert.Nil(t, err)
+			assert.Equal(t, tt.expected, got)
 
 			// If we have an expected result, verify we can decode it back
 			if tt.expected != "" {

--- a/pkg/api/v1/server_test.go
+++ b/pkg/api/v1/server_test.go
@@ -502,7 +502,6 @@ func TestIntegrationServerGet(t *testing.T) {
 			serverID: dbtools.FixtureNemo.ID,
 			params: &fleetdbapi.ServerGetParams{
 				IncludeComponents: true,
-				ComponentParams:   &fleetdbapi.ServerComponentGetParams{},
 			},
 			verifyFn: func(t *testing.T, srv *fleetdbapi.Server) {
 				assert.NotEmpty(t, srv.Components)
@@ -510,6 +509,40 @@ func TestIntegrationServerGet(t *testing.T) {
 				for _, comp := range srv.Components {
 					foundComponents[comp.UUID.String()] = true
 				}
+				assert.True(t, foundComponents[dbtools.FixtureNemoLeftFin.ID])
+				assert.True(t, foundComponents[dbtools.FixtureNemoRightFin.ID])
+
+				assert.Equal(t, dbtools.FixtureHardwareVendorBar.Name, srv.Vendor)
+				assert.Equal(t, dbtools.FixtureHardwareModelBar123.Name, srv.Model)
+			},
+		},
+		{
+			name:     "get with components and thier attributes",
+			serverID: dbtools.FixtureNemo.ID,
+			params: &fleetdbapi.ServerGetParams{
+				IncludeComponents: true,
+				ComponentParams: &fleetdbapi.ServerComponentGetParams{
+					InstalledFirmware: true,
+					Status:            true,
+					Capabilities:      true,
+				},
+			},
+			verifyFn: func(t *testing.T, srv *fleetdbapi.Server) {
+				assert.NotEmpty(t, srv.Components)
+				foundComponents := make(map[string]bool)
+				for _, comp := range srv.Components {
+					assert.NotNil(t, comp.InstalledFirmware)
+					assert.NotEmpty(t, comp.InstalledFirmware.Version)
+
+					assert.NotNil(t, comp.Status)
+					assert.NotEmpty(t, comp.Status.State)
+
+					assert.NotNil(t, comp.Capabilities)
+					assert.NotEmpty(t, comp.Capabilities[0].Description)
+
+					foundComponents[comp.UUID.String()] = true
+				}
+
 				assert.True(t, foundComponents[dbtools.FixtureNemoLeftFin.ID])
 				assert.True(t, foundComponents[dbtools.FixtureNemoRightFin.ID])
 


### PR DESCRIPTION
- Fixes server component query params encode
- Server component attributes are now returned based on the query params
- Removes requirement for server component ID in component status - to allow component records to be initialized.